### PR TITLE
Proposal for workflow: Automated publish to pypi

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,0 +1,34 @@
+name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+
+on: push
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@master
+      with:
+        fetch-depth: 20
+    - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install pep517 and twine
+      run: python -m pip install pep517 twine --user
+    - name: Build a binary wheel and a source tarball
+      run: python -m pep517.build --source --binary --out-dir dist/ ./
+    - name: twine check
+      run: python -m twine check dist/*
+    - name: Publish distribution 📦 to Test PyPI
+      if: startsWith(github.event.ref, 'refs/heads/master')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.testpypi_password }}
+        repository_url: https://test.pypi.org/legacy/
+    - name: Publish distribution 📦 to PyPI
+      if: startsWith(github.event.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.pypi_password }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,42 @@
+[metadata]
+name = sphinx-a4doc
+version = 1.2.1
+description = Sphinx domain and autodoc for Antlr4 grammars
+long_description = file: readme
+long_description_content_type = text/markdown
+python_requires = '>=3.7'
+author = Vladimir Goncharov
+author_email = dev.zelta@gmail.com
+url = https://github.com/AmatanHead/sphinx-a4doc
+license = MIT
+keywords = sphinx antlr4 autodoc
+classifiers =
+    Development Status :: 5 - Production
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3'
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    License :: OSI Approved :: MIT License
+    Framework :: Sphinx
+    Framework :: Sphinx :: Extension
+    Topic :: Software Development :: Documentation
+    Topic :: Documentation
+    Topic :: Documentation :: Sphinx
+
+[options]
+zip_safe = False
+include_package_data = True
+install_requires =
+    sphinx>=1.8.0
+    antlr4-python3-runtime==4.7.1
+    PyYAML
+setup_requires =
+    setuptools
+    wheel
+    pep517
+packages = find:
+
+[options.package_data]
+sphinx_a4doc =
+    _static/a4_railroad_diagram.css
+

--- a/setup.py
+++ b/setup.py
@@ -1,45 +1,8 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
-with open('README.md', encoding='utf-8') as readme_file:
-    readme = readme_file.read()
-    readme = readme[:readme.find('<!--- cut --->')]
-
-setup(
-    name='sphinx-a4doc',
-    version='1.2.1',
-    description='Sphinx domain and autodoc for Antlr4 grammars',
-    long_description=readme,
-    long_description_content_type='text/markdown',
-    author='Vladimir Goncharov',
-    author_email='dev.zelta@gmail.com',
-    url='https://github.com/AmatanHead/sphinx-a4doc',
-    packages=find_packages(),
-    install_requires=[
-        'sphinx>=1.8.0',
-        'antlr4-python3-runtime==4.7.1',
-        'PyYAML'
-    ],
-    python_requires='>=3.7',
-    license='MIT',
-    keywords='sphinx antlr4 autodoc',
-    project_urls={
+setup(project_urls={
         'Documentation': 'https://amatanhead.github.io/sphinx-a4doc/',
         'Source': 'https://github.com/AmatanHead/sphinx-a4doc',
         'Tracker': 'https://github.com/AmatanHead/sphinx-a4doc/issues',
-    },
-    classifiers=[
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
-        'License :: OSI Approved :: MIT License',
-        'Framework :: Sphinx',
-        'Framework :: Sphinx :: Extension',
-        'Topic :: Software Development :: Documentation',
-        'Topic :: Documentation',
-        'Topic :: Documentation :: Sphinx',
-    ],
-    zip_safe=False,
-    package_data={
-        'sphinx_a4doc': ['_static/a4_railroad_diagram.css'],
-    },
-)
+    })
+


### PR DESCRIPTION
Maintainer can automate release work with Github actions with this GHA script.

- Release automation proposal.
- setup.cfg only build configuration 
- Support PEP517 and pyproject.toml


## Preparation

1. store pypi token at  github secret 'pypi_password' and 'testpypi_password'.

There is a [detailed guile for preparation](https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/)


## Action

Whenever you push a tagged commit to your Git repository remote on GitHub, this workflow will publish it to PyPI. 
When push master branch to github, an action make a package and  testing upload to test.pypi.org.

## Further improvement

You can use setuptools_scm which help automation of versioning with git tag.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>
